### PR TITLE
Added secondary sort condition to DateComparator class.

### DIFF
--- a/src/net/foxopen/jira/changelog/JiraAPI.java
+++ b/src/net/foxopen/jira/changelog/JiraAPI.java
@@ -233,7 +233,7 @@ class DateComparator implements Comparator<VersionInfo>
     } else if (a.getReleaseDate().before(b.getReleaseDate())) {
       return 1;
     } else {
-      return 0;
+      return -(a.getName().compareTo(b.getName()));
     }
   }
 }

--- a/test/net/foxopen/jira/changelog/ChangelogTemplateTest.java
+++ b/test/net/foxopen/jira/changelog/ChangelogTemplateTest.java
@@ -38,6 +38,9 @@ public class ChangelogTemplateTest extends TestCase {
 		versions = new LinkedList<VersionInfo>();
 		VersionInfo version = new VersionInfo("2.0.1", "Bug fix release for 2.0.0", new Date(), issues);
 		versions.add(version);
+		version = new VersionInfo("2.0.2", "Bug fix release for 2.0.0", new Date(), issues);
+		versions.add(version);
+		
 		
 		output = new StringWriter();
 	}


### PR DESCRIPTION
Sorts by version number in descending order if the release dates of two or more versions are identical.
Updated test case class to reflect changes.

Signed-off-by: Andrew Pigram andrew.pigram@fivium.co.uk
